### PR TITLE
Update to more modern things

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM debian:wheezy-slim
+FROM debian:stable-slim
 LABEL maintainer="john.k.tims@gmail.com"
 
-ENV FAH_VERSION_MINOR=7.4.4
-ENV FAH_VERSION_MAJOR=7.4
+ENV FAH_VERSION_MINOR=7.5.1
+ENV FAH_VERSION_MAJOR=7.5
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
-        curl adduser bzip2 &&\
-        curl --insecure https://folding.stanford.edu/releases/public/release/fahclient/debian-testing-64bit/v${FAH_VERSION_MAJOR}/fahclient_${FAH_VERSION_MINOR}_amd64.deb > /tmp/fah.deb &&\
+        curl adduser bzip2 ca-certificates &&\
+        curl -o /tmp/fah.deb https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/v${FAH_VERSION_MAJOR}/fahclient_${FAH_VERSION_MINOR}_amd64.deb &&\
         mkdir -p /etc/fahclient/ &&\
         touch /etc/fahclient/config.xml &&\
         dpkg --install /tmp/fah.deb &&\


### PR DESCRIPTION
- Install ca-certificates to not need --insecure
- Update FAH version numbers
- Update Debian base image